### PR TITLE
feat: Improve order of edges' signal updates

### DIFF
--- a/docs/hra-node-dist-vis.wc.js
+++ b/docs/hra-node-dist-vis.wc.js
@@ -62060,16 +62060,18 @@ void main(void) {
       if (version !== this.edgesVersion) {
         return void 0;
       }
+      let edges = [];
       if (url) {
-        return await fetchCsv(url, { header: false });
+        edges = await fetchCsv(url, { header: false });
+      } else {
+        const nodeKey = this.nodeTargetKey.value;
+        const nodeValue = this.nodeTargetValue.value;
+        const maxDist = this.maxEdgeDistance.value;
+        console.log("start", /* @__PURE__ */ new Date());
+        edges = await distanceEdges(nodes, nodeKey, nodeValue, maxDist);
+        console.log("end", /* @__PURE__ */ new Date());
       }
-      const nodeKey = this.nodeTargetKey.value;
-      const nodeValue = this.nodeTargetValue.value;
-      const maxDist = this.maxEdgeDistance.value;
-      console.log("start", /* @__PURE__ */ new Date());
-      const edges = await distanceEdges(nodes, nodeKey, nodeValue, maxDist);
-      console.log("end", /* @__PURE__ */ new Date());
-      return edges;
+      return version === this.edgesVersion ? edges : void 0;
     });
     colorCoding = a();
     colorCoding$ = p(async () => {

--- a/docs/hra-node-dist-vis.wc.js
+++ b/docs/hra-node-dist-vis.wc.js
@@ -62311,6 +62311,13 @@ void main(void) {
       this.toDispose.forEach((dispose) => dispose());
       this.toDispose = [];
     }
+    toDataUrl(type, quality) {
+      if (!this.deck) {
+        return void 0;
+      }
+      this.deck.redraw(true);
+      return this.$canvas.toDataURL(type, quality);
+    }
   };
   window.customElements.define("hra-node-dist-vis", HraNodeDistanceVisualization);
 })();

--- a/docs/hra-node-dist-vis.wc.js
+++ b/docs/hra-node-dist-vis.wc.js
@@ -62007,7 +62007,6 @@ void main(void) {
 </style>
 <canvas id="vis"></canvas>
 `;
-  var emptyImmutableArray = Object.freeze([]);
   var HraNodeDistanceVisualization = class extends HTMLElement {
     static observedAttributes = [
       "nodes",
@@ -62034,9 +62033,9 @@ void main(void) {
     toDispose = [];
     initialized = false;
     edgesVersion = 0;
-    nodes = a(emptyImmutableArray);
+    nodes = a([]);
     nodes$ = p(async () => {
-      let nodes = emptyImmutableArray;
+      let nodes = [];
       if (this.nodesData.value) {
         nodes = this.nodesData.value;
       } else if (this.nodesUrl.value) {
@@ -62047,21 +62046,22 @@ void main(void) {
       }
       return nodes;
     });
-    edges = a(emptyImmutableArray);
+    edges = a([]);
     edges$ = p(async () => {
       const nodes = this.nodes.value;
-      const version = this.edgesVersion;
+      const version = this.edgesVersion += 1;
       if (nodes.length === 0) {
-        return emptyImmutableArray;
+        return void 0;
       } else if (this.edgesData.value) {
         return this.edgesData.value;
       }
+      const url = this.edgesUrl.value;
       await delay(100);
       if (version !== this.edgesVersion) {
-        return emptyImmutableArray;
+        return void 0;
       }
-      if (this.edgesUrl.value) {
-        return await fetchCsv(this.edgesUrl.value, { header: false });
+      if (url) {
+        return await fetchCsv(url, { header: false });
       }
       const nodeKey = this.nodeTargetKey.value;
       const nodeValue = this.nodeTargetValue.value;
@@ -62249,17 +62249,16 @@ void main(void) {
       );
       this.trackDisposal(
         O(async () => {
-          this.nodes.value = emptyImmutableArray;
+          this.nodes.value = [];
           this.nodes.value = await this.nodes$.value;
           this.dispatch("nodes", this.nodes.value);
         })
       );
       this.trackDisposal(
         O(async () => {
-          const version = this.edgesVersion += 1;
-          this.edges.value = emptyImmutableArray;
+          this.edges.value = [];
           const edges = await this.edges$.value;
-          if (version === this.edgesVersion) {
+          if (edges) {
             this.edges.value = edges;
             this.dispatch("edges", this.edges.value);
           }

--- a/src/hra-node-dist-vis.js
+++ b/src/hra-node-dist-vis.js
@@ -385,6 +385,16 @@ class HraNodeDistanceVisualization extends HTMLElement {
     this.toDispose.forEach((dispose) => dispose());
     this.toDispose = [];
   }
+
+  toDataUrl(type, quality) {
+    if (!this.deck) {
+      return undefined;
+    }
+
+    // See https://github.com/visgl/deck.gl/discussions/6909#discussioncomment-5167898
+    this.deck.redraw(true);
+    return this.$canvas.toDataURL(type, quality);
+  }
 }
 
 window.customElements.define('hra-node-dist-vis', HraNodeDistanceVisualization);

--- a/src/hra-node-dist-vis.js
+++ b/src/hra-node-dist-vis.js
@@ -53,6 +53,8 @@ template.innerHTML = `<style>
 <canvas id="vis"></canvas>
 `;
 
+const emptyImmutableArray = Object.freeze([]);
+
 class HraNodeDistanceVisualization extends HTMLElement {
   static observedAttributes = [
     'nodes',
@@ -78,10 +80,11 @@ class HraNodeDistanceVisualization extends HTMLElement {
   viewState = signal();
   toDispose = [];
   initialized = false;
+  edgesVersion = 0;
 
-  nodes = signal([]);
+  nodes = signal(emptyImmutableArray);
   nodes$ = computed(async () => {
-    let nodes = [];
+    let nodes = emptyImmutableArray;
     if (this.nodesData.value) {
       nodes = this.nodesData.value;
     } else if (this.nodesUrl.value) {
@@ -94,26 +97,33 @@ class HraNodeDistanceVisualization extends HTMLElement {
     return nodes;
   });
 
-  edges = signal([]);
+  edges = signal(emptyImmutableArray);
   edges$ = computed(async () => {
     const nodes = this.nodes.value;
-    if (this.edgesData.value && nodes.length > 0) {
+    const version = this.edgesVersion;
+
+    if (nodes.length === 0) {
+      return emptyImmutableArray;
+    } else if (this.edgesData.value) {
       return this.edgesData.value;
-    } else if (this.edgesUrl.value && nodes.length > 0) {
-      await delay(100);
-      const edges = await fetchCsv(this.edgesUrl.value, { header: false });
-      return edges;
-    } else if (nodes.length > 0) {
-      const nodeKey = this.nodeTargetKey.value;
-      const nodeValue = this.nodeTargetValue.value;
-      const maxDist = this.maxEdgeDistance.value;
-      console.log('start', new Date());
-      const edges = await distanceEdges(nodes, nodeKey, nodeValue, maxDist);
-      console.log('end', new Date());
-      return edges;
-    } else {
-      return [];
     }
+
+    await delay(100);
+    if (version !== this.edgesVersion) {
+      return emptyImmutableArray;
+    }
+
+    if (this.edgesUrl.value) {
+      return await fetchCsv(this.edgesUrl.value, { header: false });
+    }
+
+    const nodeKey = this.nodeTargetKey.value;
+    const nodeValue = this.nodeTargetValue.value;
+    const maxDist = this.maxEdgeDistance.value;
+    console.log('start', new Date());
+    const edges = await distanceEdges(nodes, nodeKey, nodeValue, maxDist);
+    console.log('end', new Date());
+    return edges;
   });
 
   colorCoding = signal();
@@ -154,14 +164,17 @@ class HraNodeDistanceVisualization extends HTMLElement {
       return undefined;
     }
 
-    return (attr) =>
-      colorCategories({
-        attr,
-        domain: colorDomain,
-        colors: colorRange,
-        othersColor: [255, 255, 255],
-        nullColor: [255, 255, 255],
-      });
+    return {
+      range: colorRange,
+      create: (attr) =>
+        colorCategories({
+          attr,
+          domain: colorDomain,
+          colors: colorRange,
+          othersColor: [255, 255, 255],
+          nullColor: [255, 255, 255],
+        }),
+    }
   });
 
   positionScaling = computed(() => {
@@ -189,10 +202,13 @@ class HraNodeDistanceVisualization extends HTMLElement {
         id: 'nodes',
         data: this.nodes.value,
         getPosition: this.positionScaling.value((d) => d.position),
-        getColor: this.colorCoding.value((d) => d[nodeKey]),
+        getColor: this.colorCoding.value.create((d) => d[nodeKey]),
         pickable: true,
         coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
         pointSize: 1.5,
+        updateTriggers: {
+          getColor: this.colorCoding.value.range
+        },
       });
     } else {
       return undefined;
@@ -208,10 +224,13 @@ class HraNodeDistanceVisualization extends HTMLElement {
         data: this.edges.value,
         getSourcePosition: this.positionScaling.value(([node_index, sx, sy, sz, tx, ty, tz]) => [sx, sy, sz]),
         getTargetPosition: this.positionScaling.value(([node_index, sx, sy, sz, tx, ty, tz]) => [tx, ty, tz]),
-        getColor: this.colorCoding.value(([node_index]) => nodes[node_index][nodeKey]),
+        getColor: this.colorCoding.value.create(([node_index]) => nodes[node_index][nodeKey]),
         pickable: false,
         coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
         getWidth: 1,
+        updateTriggers: {
+          getColor: this.colorCoding.value.range
+        },
       });
     } else {
       return undefined;
@@ -298,7 +317,7 @@ class HraNodeDistanceVisualization extends HTMLElement {
 
     this.trackDisposal(
       effect(async () => {
-        this.nodes.value = [];
+        this.nodes.value = emptyImmutableArray;
         this.nodes.value = await this.nodes$.value;
         this.dispatch('nodes', this.nodes.value);
       })
@@ -306,9 +325,14 @@ class HraNodeDistanceVisualization extends HTMLElement {
 
     this.trackDisposal(
       effect(async () => {
-        this.edges.value = [];
-        this.edges.value = await this.edges$.value;
-        this.dispatch('edges', this.edges.value);
+        const version = (this.edgesVersion += 1);
+        this.edges.value = emptyImmutableArray;
+
+        const edges = await this.edges$.value;
+        if (version === this.edgesVersion) {
+          this.edges.value = edges;
+          this.dispatch('edges', this.edges.value);
+        }
       })
     );
 

--- a/src/hra-node-dist-vis.js
+++ b/src/hra-node-dist-vis.js
@@ -112,17 +112,19 @@ class HraNodeDistanceVisualization extends HTMLElement {
       return undefined;
     }
 
+    let edges = [];
     if (url) {
-      return await fetchCsv(url, { header: false });
+      edges = await fetchCsv(url, { header: false });
+    } else {
+      const nodeKey = this.nodeTargetKey.value;
+      const nodeValue = this.nodeTargetValue.value;
+      const maxDist = this.maxEdgeDistance.value;
+      console.log('start', new Date());
+      edges = await distanceEdges(nodes, nodeKey, nodeValue, maxDist);
+      console.log('end', new Date());
     }
 
-    const nodeKey = this.nodeTargetKey.value;
-    const nodeValue = this.nodeTargetValue.value;
-    const maxDist = this.maxEdgeDistance.value;
-    console.log('start', new Date());
-    const edges = await distanceEdges(nodes, nodeKey, nodeValue, maxDist);
-    console.log('end', new Date());
-    return edges;
+    return version === this.edgesVersion ? edges : undefined;
   });
 
   colorCoding = signal();


### PR DESCRIPTION
Edges updates are now strictly totally ordered. Asynchronous edge computations will no longer override newer data if they complete after the new data assignment. Also update deckgl to detect changes to color maps